### PR TITLE
CEA bootcamp update

### DIFF
--- a/Dockerfile_llama2
+++ b/Dockerfile_llama2
@@ -1,0 +1,7 @@
+FROM nvcr.io/nvidia/nemo:23.10
+
+ENV XDG_RUNTIME_DIR=
+RUN pip install ujson && \
+    pip install --upgrade --no-cache-dir gdown && \
+    pip install accelerate peft bitsandbytes transformers trl && \
+    pip install spacy-langdetect 

--- a/Dockerfile_trtllm
+++ b/Dockerfile_trtllm
@@ -14,7 +14,7 @@ RUN mkdir -p /workspace/app
 WORKDIR /workspace
 
 #Clone tensorrtllm_backend repo
-RUN git clone https://github.com/triton-inference-server/tensorrtllm_backend.git
+RUN git clone https://github.com/triton-inference-server/tensorrtllm_backend.git -b v0.10.0
 RUN cd tensorrtllm_backend && rm -rf tensorrt_llm/ && ls
 
 # Install TRT-LLM 
@@ -30,7 +30,7 @@ RUN git lfs pull
 
 
 # Install TRT-LLM To build the TensorRT-LLM code.
-RUN python3 ./scripts/build_wheel.py --trt_root /usr/local/tensorrt 
+RUN MAX_JOBS=32 python3 ./scripts/build_wheel.py --trt_root /usr/local/tensorrt 
 
 # Install TRT-LLM using pip Deploy TensorRT-LLM.
 RUN pip install ./build/tensorrt_llm*.whl
@@ -38,6 +38,16 @@ RUN pip install ./build/tensorrt_llm*.whl
 # rename folder name
 RUN cd .. && mv TensorRT-LLM tensorrt_llm
 
+# Checkout v0.10.0 for compatibility with current labs version
+RUN cd /workspace/tensorrtllm_backend && git checkout v0.10.0
+
+# Patch faulty profiler.py from tensorrt_llm
+COPY profiler-py.patch /tmp
+RUN patch -i /tmp/profiler-py.patch /usr/local/lib/python3.10/dist-packages/tensorrt_llm/profiler.py
+
+# update transformers, tokenizers & accelerate
+RUN pip install --upgrade --no-cache-dir transformers tokenizers
+RUN pip install --upgrade accelerate
 
 # TensorRT-LLM Server Port 
 ENV HTTP_PORT 8000

--- a/workspace-llm-use-case/jupyter_notebook/llm-use-case/challenge.ipynb
+++ b/workspace-llm-use-case/jupyter_notebook/llm-use-case/challenge.ipynb
@@ -1291,7 +1291,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1305,7 +1305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/workspace-llm-use-case/jupyter_notebook/llm-use-case/llama-chat-finetune.ipynb
+++ b/workspace-llm-use-case/jupyter_notebook/llm-use-case/llama-chat-finetune.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ac8ace02",
+   "id": "5c792cf4",
    "metadata": {},
    "source": [
     "<p> <center> <a href=\"../../LLM-Application.ipynb\">Home Page</a> </center> </p>\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9e37cfe",
+   "id": "c9f64a75",
    "metadata": {},
    "source": [
     "# Finetuning Llama-2-7B with Custom Data\n",
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2257ba15",
+   "id": "b0297bb0",
    "metadata": {},
    "source": [
     "<div style=\"text-align:left; color:#FF0000; height:80px; text-color:red; font-size:20px\">Please note that you can only run this lab using the Llama Fine-tuning container</div>\n",
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60faf820",
+   "id": "075b53da",
    "metadata": {},
    "source": [
     "## Overview of LLAMA 2\n",
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49653722",
+   "id": "785f1894",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1fb058d",
+   "id": "3b8e547c",
    "metadata": {},
    "source": [
     "**Expected Output:**\n",
@@ -83,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41ee552e",
+   "id": "3338521a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c81ccacd",
+   "id": "c35ae9b1",
    "metadata": {},
    "source": [
     "## Text Generation\n",
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea3f2b79",
+   "id": "ba7c2d69",
    "metadata": {},
    "source": [
     "## Data Preprocessing\n",
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea427768",
+   "id": "dd92bb9d",
    "metadata": {},
    "source": [
     "### Dataset Structure\n",
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20681885",
+   "id": "4df8ede5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da488820",
+   "id": "2bab1dc6",
    "metadata": {},
    "source": [
     "**Expected Output:**\n",
@@ -180,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8472d8ea",
+   "id": "3371d68e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc880f9d",
+   "id": "6ff821e6",
    "metadata": {},
    "source": [
     "Import all required libraries "
@@ -199,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58100242",
+   "id": "781b6b48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,14 +221,14 @@
     ")\n",
     "import re\n",
     "from peft import LoraConfig, PeftModel\n",
-    "from trl import SFTTrainer\n",
+    "from trl import SFTTrainer, SFTConfig\n",
     "\n",
     "#os.environ[\"PYTORCH_CUDA_ALLOC_CONF\"] = \"max_split_size_mb:64\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "72803eb3",
+   "id": "6819cfe0",
    "metadata": {},
    "source": [
     "### Data Extraction"
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9318879",
+   "id": "68c54431",
    "metadata": {},
    "source": [
     "Let's execute the `read_jsonl` function below to read the dataset"
@@ -245,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "252c3921",
+   "id": "602d891b",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02c9e70f",
+   "id": "2005ab5a",
    "metadata": {},
    "source": [
     "Let's perform the following steps in the cell below:\n",
@@ -274,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d12179ff",
+   "id": "24ad0aba",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31f8631f",
+   "id": "d11085a9",
    "metadata": {},
    "source": [
     "**Expected output:**\n",
@@ -320,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6573baa",
+   "id": "1e9da019",
    "metadata": {},
    "source": [
     "We can see from the content displayed that the file contains text written in different languages. For demonstration purposes, we want to consider only English text for training and prompting. Therefore, the train and test sets will be processed to filter out non-English text samples using a `detect` feature from the `spacy-langdetect` library. The English-only texts (`1778 training samples`) are saved as the new training set. The same process is applied to the test samples. Run the three two cells below to execute the filter process.     "
@@ -329,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c23ee92",
+   "id": "c6982e5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1600af06",
+   "id": "eb712fee",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bdfaed0",
+   "id": "4a712a01",
    "metadata": {},
    "source": [
     "**Expected output:**\n",
@@ -384,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b40eaa4",
+   "id": "faee1e15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac0ee952",
+   "id": "7a74cda0",
    "metadata": {
     "tags": []
    },
@@ -425,7 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54a7cae2",
+   "id": "1f54ed8c",
    "metadata": {},
    "source": [
     "Next, we load the filtered dataset by running the cell below."
@@ -434,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d38a2bbb",
+   "id": "a2edd580",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -446,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c95d07b",
+   "id": "e83ce0d3",
    "metadata": {},
    "source": [
     "Execute the function to transform the filtered dataset to the format explained above."
@@ -455,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156fae02",
+   "id": "f91b1ef9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "319db668",
+   "id": "166fd1d3",
    "metadata": {},
    "source": [
     "Let's display a sample to inspect if our training set is in the right format as shown in the screenshot above."
@@ -500,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca12393b",
+   "id": "57e40480",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02d60b3c",
+   "id": "3c345eb9",
    "metadata": {},
    "source": [
     "Save the preprocessed dataset to the directory `../data/ds_preprocess`."
@@ -518,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00bb7652",
+   "id": "0ba4d0e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -527,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "246c9948",
+   "id": "1bdfb84b",
    "metadata": {},
    "source": [
     "## Fine-tuning LLAMA 2\n",
@@ -545,7 +545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "810864f9",
+   "id": "6ba3c97f",
    "metadata": {},
    "source": [
     "### Convert model to Hugging Face Transformers Format\n",
@@ -571,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65618d19",
+   "id": "98e89fe2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6322673",
+   "id": "7f15497b",
    "metadata": {},
    "source": [
     "**Exepected Output:**\n",
@@ -598,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f7b6f5c",
+   "id": "e0d81af6",
    "metadata": {},
    "source": [
     "Now, we can initialize the path to our transformer format model and load the transformed/preprocessed training dataset from the directory where it was saved. "
@@ -607,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "921d25ea",
+   "id": "2e912776",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,7 +628,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74b042cb",
+   "id": "01f5fef4",
    "metadata": {},
    "source": [
     "### Loading tokenizer\n",
@@ -646,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a94f0a7",
+   "id": "aa661931",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,7 +657,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e098f01",
+   "id": "a321f7a5",
    "metadata": {},
    "source": [
     "### Set Training Hyperparameters\n",
@@ -667,7 +667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "912b149b",
+   "id": "7438cbb5",
    "metadata": {},
    "source": [
     "**Note:** *If running on a single DGX A100 GPU, use the hyperparameter settings below to modify the next cell.*\n",
@@ -691,11 +691,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a69ec67",
+   "id": "a6562a85",
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_params = TrainingArguments(\n",
+    "os.environ[\"WANDB_DISABLED\"] = \"True\"\n",
+    "\n",
+    "training_params = SFTConfig(\n",
     "    output_dir=\"../../model/results\",\n",
     "    num_train_epochs=2,\n",
     "    per_device_train_batch_size=1,\n",
@@ -712,13 +714,15 @@
     "    warmup_ratio=0.03,\n",
     "    optim=\"paged_adamw_32bit\",\n",
     "    lr_scheduler_type=\"constant\",\n",
-    "    report_to=\"tensorboard\"\n",
+    "    max_seq_length=512,\n",
+    "    packing=False,\n",
+    "    report_to=None,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3e8e18bb",
+   "id": "77b4af34",
    "metadata": {
     "tags": []
    },
@@ -744,7 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6a836da",
+   "id": "394de49a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +763,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "446569eb",
+   "id": "26c2d3c8",
    "metadata": {},
    "source": [
     "### 4-bit quantization configuration\n",
@@ -782,7 +786,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2095193",
+   "id": "265d51f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +801,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abf85f21",
+   "id": "810ac653",
    "metadata": {},
    "source": [
     "### Loading Base Model\n",
@@ -808,7 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ec182e5",
+   "id": "1616e97d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -823,7 +827,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5bb3660",
+   "id": "eb4ee246",
    "metadata": {},
    "source": [
     "### Set the Trainer Hyperparameters\n",
@@ -836,7 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0797225",
+   "id": "f6598d84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -845,17 +849,14 @@
     "    tokenizer=tokenizer,\n",
     "    train_dataset=dataset,\n",
     "    eval_dataset = eval_dataset,\n",
-    "    dataset_text_field=\"text\",\n",
     "    peft_config=peft_params,\n",
     "    args=training_params,\n",
-    "    max_seq_length=512,\n",
-    "    packing=False,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d90bfda0",
+   "id": "aeca9681",
    "metadata": {},
    "source": [
     "Run the cell below to train the SFT trainer object. *Please note that it takes an hour or more to complete the training (each epoch takes 31 minutes or more)*."
@@ -864,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b05b27e2",
+   "id": "53d87f91",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -876,7 +877,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52ee8afe",
+   "id": "3a7afab4",
    "metadata": {},
    "source": [
     "Save the finetuning model and tokenizer in the directory  `../model/Llama-2-7b-chat-hf-finetune`"
@@ -885,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1fb2805f",
+   "id": "fad41499",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,7 +898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6188feb",
+   "id": "6e475926",
    "metadata": {},
    "source": [
     "## Inferencing\n",
@@ -921,7 +922,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bf9648d",
+   "id": "0cf847aa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -936,7 +937,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a683fd63",
+   "id": "f8948e27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,7 +947,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9aa31490",
+   "id": "71b0174e",
    "metadata": {},
    "source": [
     "**Likely output:**\n",
@@ -961,7 +962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d31c5dc4",
+   "id": "950a712e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -971,7 +972,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e9fbb65",
+   "id": "05fe4bfb",
    "metadata": {},
    "source": [
     "**Likely output:**\n",
@@ -985,7 +986,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a0a7af4",
+   "id": "410f899f",
    "metadata": {
     "tags": []
    },
@@ -997,7 +998,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21f05d16",
+   "id": "3119af4e",
    "metadata": {},
    "source": [
     "**Likely output:**\n",
@@ -1017,7 +1018,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cf34cb9",
+   "id": "978c2a1b",
    "metadata": {},
    "source": [
     "### Reload model in FP16 and merge with LoRA weights\n",
@@ -1028,7 +1029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58537fa1",
+   "id": "736eff35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1049,7 +1050,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6aaa035",
+   "id": "36e7473d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1059,7 +1060,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3f95d0a",
+   "id": "7d05487c",
    "metadata": {},
    "source": [
     "**expected output**:\n",
@@ -1076,7 +1077,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "202619b0",
+   "id": "ad94e431",
    "metadata": {},
    "source": [
     "---\n",
@@ -1085,7 +1086,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "339eafbf",
+   "id": "53fd16f5",
    "metadata": {},
    "source": [
     "- https://ai.meta.com/research/publications/llama-2-open-foundation-and-fine-tuned-chat-models/\n",
@@ -1099,7 +1100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4056ef38",
+   "id": "f91fadfd",
    "metadata": {
     "tags": []
    },
@@ -1111,7 +1112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec0e1b99",
+   "id": "be002d00",
    "metadata": {},
    "source": [
     " <div>\n",
@@ -1132,7 +1133,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1146,7 +1147,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/workspace-llm-use-case/jupyter_notebook/llm-use-case/solution.ipynb
+++ b/workspace-llm-use-case/jupyter_notebook/llm-use-case/solution.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b36f634a",
+   "id": "a33c3148",
    "metadata": {},
    "source": [
     "# Solution Prototype\n",
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72940d39",
+   "id": "ff5b45ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,24 +33,24 @@
     "    TrainingArguments,\n",
     "    pipeline,\n",
     ")\n",
-    "from trl import SFTTrainer\n"
+    "from trl import SFTTrainer, SFTConfig\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6026db2",
+   "id": "b074dc5c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = load_dataset(\"Salesforce/dialogstudio\",\"TweetSumm\")\n",
+    "dataset = load_dataset(\"Salesforce/dialogstudio\", \"TweetSumm\", cache_dir='../../data/hg-cache')\n",
     "dataset"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61c42aa9",
+   "id": "8f700dd3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c44f862",
+   "id": "240ae01c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9213c842",
+   "id": "c1aaceae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b51d879d",
+   "id": "ffb24895",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64fc8df0",
+   "id": "d65c79ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b24f21e8",
+   "id": "bf7893a0",
    "metadata": {},
    "source": [
     "Please run the cell below to check if the Llama-2-7b model already exist in your directory otherwise, uncomment the nested cell below to download it."
@@ -157,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d0b591a",
+   "id": "d694ac47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77e802b4",
+   "id": "8d55dc1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cfd5056",
+   "id": "f384f608",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -200,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20873a1b",
+   "id": "c2d42339",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "861fd753",
+   "id": "94698a49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0f318d6",
+   "id": "e5f0ea12",
    "metadata": {},
    "source": [
     "**Note:** *For a single DGX A100 GPU, please modify the values for the following parameters as follows:*\n",
@@ -238,11 +238,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b5de2f3",
+   "id": "4f1ee742",
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_arguments = TrainingArguments(\n",
+    "training_arguments = SFTConfig(\n",
     "    per_device_train_batch_size = 1,\n",
     "    gradient_accumulation_steps= 1,\n",
     "    optim = \"paged_adamw_32bit\",\n",
@@ -260,7 +260,8 @@
     "    report_to=\"tensorboard\",\n",
     "    save_safetensors=True,\n",
     "    lr_scheduler_type=\"cosine\",\n",
-    "    \n",
+    "    max_seq_length = 4096,\n",
+    "\n",
     ")\n",
     "#seed = 42,"
    ]
@@ -268,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4889714b",
+   "id": "1fee9c2e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151af477",
+   "id": "504165cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,13 +300,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b54a158a",
+   "id": "7aa436d1",
    "metadata": {},
    "outputs": [],
    "source": [
     " model = AutoModelForCausalLM.from_pretrained(\n",
     "     base_model, \n",
-    "     use_safetensors=True, \n",
+    "     use_safetensors=False, \n",
     "     quantization_config=quant_config, \n",
     "     device_map={\"\": 0},\n",
     " )\n",
@@ -316,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40f09f36",
+   "id": "2bcb6ff2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,8 +326,6 @@
     "    train_dataset = dataset[\"train\"],\n",
     "    eval_dataset = dataset[\"validation\"],\n",
     "    peft_config = peft_config,\n",
-    "    dataset_text_field = \"text\",\n",
-    "    max_seq_length = 4096,\n",
     "    tokenizer = tokenizer,\n",
     "    args = training_arguments,\n",
     "\n",
@@ -336,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1c4f152",
+   "id": "cbd38b7c",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -349,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32c0712c",
+   "id": "4572e8a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfa8b329",
+   "id": "224bc235",
    "metadata": {},
    "source": [
     "### Inference"
@@ -369,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e019427b",
+   "id": "f4b203eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6720f20",
+   "id": "e2bc60d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da0642dd",
+   "id": "59fe0deb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "187ccd96",
+   "id": "c9334f7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4044652a",
+   "id": "9e2dda8b",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -463,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01839c1e",
+   "id": "f33b8b49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f658ed0d",
+   "id": "66fbf129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +498,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7134d83",
+   "id": "ba085212",
    "metadata": {},
    "source": [
     "---\n",
@@ -510,7 +509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af176b1b",
+   "id": "7744a715",
    "metadata": {},
    "source": [
     "### Build the LLaMA 7B model using a single GPU and apply INT8 weight-only quantization\n",
@@ -523,13 +522,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2030fcae",
+   "id": "f05bfc08",
    "metadata": {},
    "outputs": [],
    "source": [
     "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/llama/convert_checkpoint.py \\\n",
-    "                            --model_dir /workspace/app/model/challenge/Llama-2-7b-hf-merged  \\\n",
-    "                            --output_dir /workspace/app/model/challenge/tllm_checkpoint_1gpu_fp16_wq \\\n",
+    "                            --model_dir ../../model/challenge/Llama-2-7b-hf-merged  \\\n",
+    "                            --output_dir ../../model/challenge/tllm_checkpoint_1gpu_fp16_wq \\\n",
     "                            --dtype float16 \\\n",
     "                            --use_weight_only \\\n",
     "                            --weight_only_precision int8"
@@ -537,7 +536,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f461ced3",
+   "id": "dcf005e6",
    "metadata": {},
    "source": [
     "- Build Tensorrt Engine"
@@ -546,20 +545,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed06e91e",
+   "id": "0dde29aa",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "!trtllm-build --checkpoint_dir /workspace/app/model/challenge/tllm_checkpoint_1gpu_fp16_wq  \\\n",
-    "              --output_dir /workspace/app/model/challenge/trt_engines/weight_only/1-gpu/ \\\n",
+    "!trtllm-build --checkpoint_dir ../../model/challenge/tllm_checkpoint_1gpu_fp16_wq  \\\n",
+    "              --output_dir ../../model/challenge/trt_engines/weight_only/1-gpu/ \\\n",
     "              --gemm_plugin float16"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "def2943b",
+   "id": "66ca77c5",
    "metadata": {},
    "source": [
     "- Run Inference using the dataset from `ccdv/cnn_dailymail`"
@@ -568,22 +567,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ad864f9",
+   "id": "6813a3df",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/summarize.py \\\n",
+    "!HF_HUB_OFFLINE=1 python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/summarize.py \\\n",
     "                       --test_trt_llm \\\n",
-    "                       --hf_model_dir /workspace/app/model/Llama-2-7b-hf-merged  \\\n",
+    "                       --hf_model_dir ../../model/challenge/Llama-2-7b-hf-merged  \\\n",
     "                       --data_type fp16 \\\n",
-    "                       --engine_dir /workspace/app/model/challenge/trt_engines/weight_only/1-gpu/"
+    "                       --engine_dir ../../model/challenge/trt_engines/weight_only/1-gpu/ \\\n",
+    "                       --dataset_path ../../data/hg-cache"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3a524fe5",
+   "id": "46c994a1",
    "metadata": {},
    "source": [
     "Likely Output:\n",
@@ -615,7 +615,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9db4967",
+   "id": "491f6acc",
    "metadata": {},
    "source": [
     "---"
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "908a908a",
+   "id": "4d508006",
    "metadata": {},
    "source": [
     "\n",
@@ -635,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0f26723",
+   "id": "d47b79a3",
    "metadata": {},
    "source": [
     "### Modify the model configuration\n",
@@ -649,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7885509e",
+   "id": "1c37b36e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -660,37 +660,37 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8174a45",
+   "id": "dc0db8b2",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
     "# Create the model repository that will be used by the Triton server\n",
-    "cd /workspace/app/source_code/tensorrtllm_backend/\n",
-    "mkdir triton_model_repo\n",
+    "cd ../../source_code/tensorrtllm_backend/\n",
+    "mkdir -p triton_model_repo\n",
     "\n",
     "# Copy the example models to the model repository\n",
     "mkdir -p triton_model_repo/tensorrt_llm/3\n",
     "cp -r all_models/inflight_batcher_llm/* triton_model_repo/\n",
     "\n",
     "# Copy the TRT engine to triton_model_repo/tensorrt_llm/1/\n",
-    "cp  /workspace/app/model/trt_engines/fp16/1-gpu/* triton_model_repo/tensorrt_llm/3"
+    "cp  ../../model/trt_engines/fp16/1-gpu/* triton_model_repo/tensorrt_llm/3"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4fc3b99",
+   "id": "f92e9958",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
     "# Run this script to set the right key-value pairs automatically.\n",
     "\n",
-    "cd /workspace/app/source_code/tensorrtllm_backend/\n",
+    "cd ../../source_code/tensorrtllm_backend/\n",
     "\n",
-    "export HF_LLAMA_MODEL=\"/workspace/app/model/challenge/Llama-2-7b-hf-merged\"\n",
-    "export    ENGINE_PATH=\"/workspace/app/source_code/tensorrtllm_backend/triton_model_repo/tensorrt_llm/3\" \n",
+    "export HF_LLAMA_MODEL=\"../../model/challenge/Llama-2-7b-hf-merged\"\n",
+    "export    ENGINE_PATH=\"../../source_code/tensorrtllm_backend/triton_model_repo/tensorrt_llm/3\" \n",
     "export BACKEND=\"tensorrtllm\"\n",
     "\n",
     "\n",
@@ -703,7 +703,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "195cecde",
+   "id": "e2f580e5",
    "metadata": {},
    "source": [
     "#### Option 2: Complete The Task Below"
@@ -712,24 +712,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe810cc8",
+   "id": "2c1026ce",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
     "# Create the model repository that will be used by the Triton server\n",
-    "cd /workspace/app/source_code/tensorrtllm_backend/\n",
+    "cd ../../source_code/tensorrtllm_backend/\n",
     "\n",
     "# make TRT engine folder for triton \n",
     "mkdir -p triton_model_repo/tensorrt_llm/3\n",
     "\n",
     "# Copy the TRT engine to triton_model_repo/tensorrt_llm/3\n",
-    "cp  /workspace/app/model/challenge/trt_engines/weight_only/1-gpu/* triton_model_repo/tensorrt_llm/3"
+    "cp  ../../model/challenge/trt_engines/weight_only/1-gpu/* triton_model_repo/tensorrt_llm/3"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dd93fa66",
+   "id": "6db2433e",
    "metadata": {},
    "source": [
     "\n",
@@ -772,7 +772,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb8b4ca1",
+   "id": "ff9a40ea",
    "metadata": {},
    "source": [
     "### Launch Triton server\n",
@@ -780,14 +780,14 @@
     "We can launch the Triton server with the following command:\n",
     "\n",
     "- Press `Crtl+Shift+L` and open a new terminal\n",
-    "- On the terminal, navigate to the launch script folder by running this command: `cd /workspace/app/source_code/tensorrtllm_backend`\n",
-    "- Start the Triton Server with this command: `python3 scripts/launch_triton_server.py  --world_size=1  --model_repo=/workspace/app/source_code/tensorrtllm_backend/triton_model_repo`\n"
+    "- On the terminal, navigate to the launch script folder by running this command: `cd ../../source_code/tensorrtllm_backend`\n",
+    "- Start the Triton Server with this command: `python3 scripts/launch_triton_server.py  --world_size=1  --model_repo=triton_model_repo`\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcece6f7",
+   "id": "d741d231",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,7 +809,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7b8bc7e",
+   "id": "5deeeac0",
    "metadata": {},
    "source": [
     "### Querying using Python"
@@ -818,7 +818,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f39bd26",
+   "id": "6821492d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -842,7 +842,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4758159",
+   "id": "03e6975e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +852,7 @@
     "    \"text_input\": INPUT_TEXT,\n",
     "    \"max_tokens\": 256,\n",
     "    \"bad_words\": \"\",\n",
-    "    \"stop_words\": \"\\n\"\n",
+    "    \"stop_words\": \"\"\n",
     "}\n",
     "\n",
     "# Make a POST request\n",
@@ -877,7 +877,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02a5413e",
+   "id": "2f85a4f4",
    "metadata": {},
    "source": [
     "Likely Output:\n",
@@ -909,7 +909,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ab58058",
+   "id": "fe8002a8",
    "metadata": {},
    "source": [
     "---\n",
@@ -921,7 +921,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -935,7 +935,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/workspace-llm-use-case/jupyter_notebook/llm-use-case/triton-llama.ipynb
+++ b/workspace-llm-use-case/jupyter_notebook/llm-use-case/triton-llama.ipynb
@@ -80,8 +80,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# copy tensorrtllm_backend to source_code\n",
-    "!cp -r /workspace/tensorrtllm_backend /workspace/app/source_code"
+    "# copy tensorrtllm_backend to source_code if not already present\n",
+    "!cp -r /workspace/tensorrtllm_backend ../../source_code"
    ]
   },
   {
@@ -101,14 +101,14 @@
    "source": [
     "%%bash\n",
     "# Create the model repository that will be used by the Triton server\n",
-    "cd /workspace/app/source_code/tensorrtllm_backend/\n",
+    "cd ../../source_code/tensorrtllm_backend/\n",
     "mkdir triton_model_repo\n",
     "\n",
     "# Copy the example models to the model repository\n",
     "cp -r all_models/inflight_batcher_llm/* triton_model_repo/\n",
     "\n",
     "# Copy the TRT engine to triton_model_repo/tensorrt_llm/1/\n",
-    "cp  /workspace/app/model/trt_engines/fp16/1-gpu/* triton_model_repo/tensorrt_llm/1"
+    "cp  ../../model/trt_engines/fp16/1-gpu/* triton_model_repo/tensorrt_llm/1"
    ]
   },
   {
@@ -138,10 +138,10 @@
     "%%bash\n",
     "# Run this script to set the right key-value pairs automatically.\n",
     "\n",
-    "cd /workspace/app/source_code/tensorrtllm_backend/\n",
+    "cd ../../source_code/tensorrtllm_backend/\n",
     "\n",
-    "export HF_LLAMA_MODEL=\"/workspace/app/model/Llama-2-7b-chat-hf-merged\"\n",
-    "export    ENGINE_PATH=\"/workspace/app/source_code/tensorrtllm_backend/triton_model_repo/tensorrt_llm/1\" \n",
+    "export HF_LLAMA_MODEL=\"../../model/Llama-2-7b-chat-hf-merged\"\n",
+    "export    ENGINE_PATH=\"../../source_code/tensorrtllm_backend/triton_model_repo/tensorrt_llm/1\" \n",
     "export BACKEND=\"tensorrtllm\"\n",
     "\n",
     "\n",
@@ -235,8 +235,8 @@
     "\n",
     "- Press `Crtl+Shift+L` and open a new terminal\n",
     "  <center><img src=\"images/terminal.png\"  alt-text=\"terminal\"/></center>\n",
-    "- On the terminal, navigate to the launch script folder by running this command: `cd /workspace/app/source_code/tensorrtllm_backend`\n",
-    "- Start the Triton Server with this command: `python3 scripts/launch_triton_server.py  --world_size=1  --model_repo=/workspace/app/source_code/tensorrtllm_backend/triton_model_repo`\n",
+    "- On the terminal, navigate to the launch script folder by running this command: `cd ../../source_code/tensorrtllm_backend`\n",
+    "- Start the Triton Server with this command: `python3 scripts/launch_triton_server.py  --world_size=1  --model_repo=triton_model_repo`\n",
     "\n",
     "\n",
     "It will take a few minutes to run and when successfully deployed, the server produces logs similar to the screenshot below.\n",
@@ -374,7 +374,7 @@
     "    \"text_input\": input_text,\n",
     "    \"max_tokens\": 200,\n",
     "    \"bad_words\": \"\",\n",
-    "    \"stop_words\": \"\\n\"\n",
+    "    \"stop_words\": \"\"\n",
     "}\n",
     "\n",
     "# Make a POST request\n",
@@ -512,7 +512,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 /workspace/app/source_code/tensorrtllm_backend/tools/inflight_batcher_llm/end_to_end_test.py  \\\n",
+    "!python3 ../../source_code/tensorrtllm_backend/tools/inflight_batcher_llm/end_to_end_test.py  \\\n",
     "         --dataset  ../../data/simple_data.json  \\\n",
     "         --max-input-len 500"
    ]
@@ -573,13 +573,13 @@
    "source": [
     "%%bash\n",
     "# Create the model repository that will be used by the Triton server\n",
-    "cd /workspace/app/source_code/tensorrtllm_backend/\n",
+    "cd ../../source_code/tensorrtllm_backend/\n",
     "\n",
     "# make TRT engine folder for triton \n",
     "mkdir -p triton_model_repo/tensorrt_llm/2\n",
     "\n",
     "# Copy the TRT engine to triton_model_repo/tensorrt_llm/2\n",
-    "cp  /workspace/app/model/trt_engines/weight_only/1-gpu/* triton_model_repo/tensorrt_llm/2"
+    "cp  ../../model/trt_engines/weight_only/1-gpu/* triton_model_repo/tensorrt_llm/2"
    ]
   },
   {
@@ -595,8 +595,8 @@
     "\n",
     "- Launch Triton server\n",
     "    - Press `Crtl+Shift+L` and open a new terminal\n",
-    "    - On the terminal, navigate to the launch script folder by running this command: `cd /workspace/app/source_code/tensorrtllm_backend`\n",
-    "    - Start the Triton Server with this command: `python3 scripts/launch_triton_server.py  --world_size=1  --model_repo=/workspace/app/source_code/tensorrtllm_backend/triton_model_repo`"
+    "    - On the terminal, navigate to the launch script folder by running this command: `cd ../../source_code/tensorrtllm_backend`\n",
+    "    - Start the Triton Server with this command: `python3 scripts/launch_triton_server.py  --world_size=1  --model_repo=triton_model_repo`"
    ]
   },
   {
@@ -624,7 +624,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 /workspace/app/source_code/tensorrtllm_backend/tools/inflight_batcher_llm/end_to_end_test.py  \\\n",
+    "!python3 ../../source_code/tensorrtllm_backend/tools/inflight_batcher_llm/end_to_end_test.py  \\\n",
     "         --dataset  ../../data/simple_data.json \\\n",
     "         --max-input-len 500"
    ]
@@ -711,7 +711,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -725,7 +725,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/workspace-llm-use-case/jupyter_notebook/llm-use-case/trt-custom-model.ipynb
+++ b/workspace-llm-use-case/jupyter_notebook/llm-use-case/trt-custom-model.ipynb
@@ -305,7 +305,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -319,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/workspace-llm-use-case/jupyter_notebook/llm-use-case/trt-llama-chat.ipynb
+++ b/workspace-llm-use-case/jupyter_notebook/llm-use-case/trt-llama-chat.ipynb
@@ -138,8 +138,8 @@
    "outputs": [],
    "source": [
     "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/llama/convert_checkpoint.py \\\n",
-    "                              --model_dir /workspace/app/model/Llama-2-7b-chat-hf-merged \\\n",
-    "                              --output_dir /workspace/app/model/tllm_checkpoint_1gpu_fp16 \\\n",
+    "                              --model_dir ../../model/Llama-2-7b-chat-hf-merged \\\n",
+    "                              --output_dir ../../model/tllm_checkpoint_1gpu_fp16 \\\n",
     "                              --dtype float16"
    ]
   },
@@ -169,8 +169,8 @@
    },
    "outputs": [],
    "source": [
-    "!trtllm-build --checkpoint_dir /workspace/app/model/tllm_checkpoint_1gpu_fp16 \\\n",
-    "            --output_dir /workspace/app/model/trt_engines/fp16/1-gpu \\\n",
+    "!trtllm-build --checkpoint_dir ../../model/tllm_checkpoint_1gpu_fp16 \\\n",
+    "            --output_dir ../../model/trt_engines/fp16/1-gpu \\\n",
     "            --gemm_plugin float16"
    ]
   },
@@ -206,8 +206,8 @@
     "# With fp16 inference\n",
     "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/run.py \\\n",
     "                  --max_output_len=200 \\\n",
-    "                  --tokenizer_dir /workspace/app/model/Llama-2-7b-chat-hf-merged \\\n",
-    "                  --engine_dir=/workspace/app/model/trt_engines/fp16/1-gpu \\\n",
+    "                  --tokenizer_dir ../../model/Llama-2-7b-chat-hf-merged \\\n",
+    "                  --engine_dir=../../model/trt_engines/fp16/1-gpu \\\n",
     "                  --input_text \"explain what is astrophotography?\"\n"
    ]
   },
@@ -250,8 +250,8 @@
    "outputs": [],
    "source": [
     "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/llama/convert_checkpoint.py \\\n",
-    "                              --model_dir /workspace/app/model/Llama-2-7b-chat-hf-merged  \\\n",
-    "                              --output_dir /workspace/app/model/tllm_checkpoint_1gpu_bf16 \\\n",
+    "                              --model_dir ../../model/Llama-2-7b-chat-hf-merged  \\\n",
+    "                              --output_dir ../../model/tllm_checkpoint_1gpu_bf16 \\\n",
     "                              --dtype bfloat16"
    ]
   },
@@ -264,8 +264,8 @@
    },
    "outputs": [],
    "source": [
-    "!trtllm-build --checkpoint_dir /workspace/app/model/tllm_checkpoint_1gpu_bf16 \\\n",
-    "            --output_dir /workspace/app/model/trt_engines/bf16/1-gpu \\\n",
+    "!trtllm-build --checkpoint_dir ../../model/tllm_checkpoint_1gpu_bf16 \\\n",
+    "            --output_dir ../../model/trt_engines/bf16/1-gpu \\\n",
     "            --gpt_attention_plugin bfloat16 \\\n",
     "            --gemm_plugin bfloat16"
    ]
@@ -279,8 +279,8 @@
    "source": [
     "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/run.py \\\n",
     "                  --max_output_len=200 \\\n",
-    "                  --tokenizer_dir /workspace/app/model/Llama-2-7b-chat-hf-merged \\\n",
-    "                  --engine_dir=/workspace/app/model/trt_engines/bf16/1-gpu \\\n",
+    "                  --tokenizer_dir ../../model/Llama-2-7b-chat-hf-merged \\\n",
+    "                  --engine_dir=../../model/trt_engines/bf16/1-gpu \\\n",
     "                  --input_text \"explain what is astrophotography?\""
    ]
   },
@@ -304,8 +304,8 @@
    "outputs": [],
    "source": [
     "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/llama/convert_checkpoint.py \\\n",
-    "                              --model_dir /workspace/app/model/Llama-2-7b-chat-hf-merged  \\\n",
-    "                              --output_dir /workspace/app/model/tllm_checkpoint_1gpu_fp16_wq \\\n",
+    "                              --model_dir ../../model/Llama-2-7b-chat-hf-merged  \\\n",
+    "                              --output_dir ../../model/tllm_checkpoint_1gpu_fp16_wq \\\n",
     "                              --dtype float16 \\\n",
     "                              --use_weight_only \\\n",
     "                              --weight_only_precision int8"
@@ -328,8 +328,8 @@
    },
    "outputs": [],
    "source": [
-    "!trtllm-build --checkpoint_dir /workspace/app/model/tllm_checkpoint_1gpu_fp16_wq  \\\n",
-    "            --output_dir /workspace/app/model/trt_engines/weight_only/1-gpu/ \\\n",
+    "!trtllm-build --checkpoint_dir ../../model/tllm_checkpoint_1gpu_fp16_wq  \\\n",
+    "            --output_dir ../../model/trt_engines/weight_only/1-gpu/ \\\n",
     "            --gemm_plugin float16"
    ]
   },
@@ -350,8 +350,8 @@
    "source": [
     "!python3 /workspace/tensorrtllm_backend/tensorrt_llm/examples/run.py \\\n",
     "                  --max_output_len=200 \\\n",
-    "                  --tokenizer_dir /workspace/app/model/Llama-2-7b-chat-hf-merged  \\\n",
-    "                  --engine_dir=/workspace/app/model/trt_engines/weight_only/1-gpu/ \\\n",
+    "                  --tokenizer_dir ../../model/Llama-2-7b-chat-hf-merged  \\\n",
+    "                  --engine_dir=../../model/trt_engines/weight_only/1-gpu/ \\\n",
     "                  --input_text \"explain what is astrophotography?\""
    ]
   },
@@ -509,7 +509,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -523,7 +523,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is for updates necessary to run the bootcamp at CEA on March, 31 & April, 1st.

The main updates concern:
- the container recipes; a Docker recipe was added for `llama2` image, and `tensorrtllm` was updated; in particular the version of `tensorrtllm_backend` has to be set explicitely for compatibility reasons;
- the hyperparameters settings that is now done with `STFConfig`;
- everything is done offline and a HuggingFace cache is used (its generation is not documented);
- all the paths for the models in lab2 & lab3 are relative to the notebook used rather than from the workspace of the container.

It might reasonably live in a separate branch if needed.